### PR TITLE
Adapt to recent changes in liballocs

### DIFF
--- a/include/libcrunch.h
+++ b/include/libcrunch.h
@@ -47,7 +47,7 @@ int __can_hold_pointer_internal(const void *target, const void *value) __attribu
 #ifndef CIL
 #include "libcrunch_cil_inlines.h"
 #endif
-__libcrunch_bounds_t __fetch_bounds_internal(const void *ptr, const void *derived_ptr, struct uniqtype *u);
+__libcrunch_bounds_t __fetch_bounds_internal(const void *ptr, const void *derived_ptr, const struct uniqtype *u);
 void * __check_derive_ptr_internal(const void *derived, const void *derivedfrom, 
 		__libcrunch_bounds_t *derivedfrom_bounds, struct uniqtype *t) PURE;
 

--- a/include/libcrunch_cil_inlines.h
+++ b/include/libcrunch_cil_inlines.h
@@ -37,6 +37,8 @@
  * the dummy return value to a global or something. */
 void warnx(const char *fmt, ...);
 void vwarnx(const char *fmt, __builtin_va_list ap);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 static void ( __attribute__((pure,noinline)) warnx_pure )(const char *fmt, ...)
 {
 	__builtin_va_list ap;
@@ -44,6 +46,7 @@ static void ( __attribute__((pure,noinline)) warnx_pure )(const char *fmt, ...)
 	vwarnx(fmt, ap);
 	__builtin_va_end(ap);
 }
+#pragma GCC diagnostic pop
 
 /* Ideally we really want to fit in 64 bits on x86-64. 
  * This makes life a bit trickier, however. 
@@ -117,7 +120,7 @@ int __is_a_pointer_of_degree_internal(const void *obj, int d) PURE;
 int __can_hold_pointer_internal(const void *obj, const void *value) PURE;
 
 /* Bounds checking */
-__libcrunch_bounds_t __fetch_bounds_internal(const void *ptr, const void *derived_ptr, struct uniqtype *u) PURE;
+__libcrunch_bounds_t __fetch_bounds_internal(const void *ptr, const void *derived_ptr, const struct uniqtype *u) PURE;
 void __libcrunch_bounds_error(const void *derived, const void *derivedfrom, 
 		__libcrunch_bounds_t bounds);
 void __libcrunch_soft_bounds_error_at(const void *ptr, __libcrunch_bounds_t bounds, const void *addr);
@@ -590,8 +593,8 @@ extern inline void *(__attribute__((always_inline,gnu_inline,used)) __libcrunch_
 //	|   /* Bottom bits of ptr */
 //		((((unsigned long long) ptr) << (8*sizeof(long long)-LIBCRUNCH_TRAP_TAG_SHIFT)
 //			>> (8*sizeof(long long) - LIBCRUNCH_TRAP_TAG_SHIFT)))
-		((unsigned long long) maybe_trapped) & ~LIBCRUNCH_TRAP_BOTTOM_MASK
-			| ((unsigned long long) ptr) & LIBCRUNCH_TRAP_BOTTOM_MASK
+		(((unsigned long long) maybe_trapped) & ~LIBCRUNCH_TRAP_BOTTOM_MASK)
+			| (((unsigned long long) ptr) & LIBCRUNCH_TRAP_BOTTOM_MASK)
 	);
 #else
 	return ptr;
@@ -909,7 +912,7 @@ extern __libcrunch_bounds_t (__attribute__((pure)) __fetch_bounds_ool)(const voi
 /* __fetch_bounds_ool_via_dladdr is not only pure, but also const since it only
  * works on static objects -- it is unaffected by changes in the global state. 
  * FIXME: this isn't really true if we get into loading/unloading shared objs! */
-extern __libcrunch_bounds_t (__attribute__((pure,__const__)) __fetch_bounds_ool_via_dladdr)(const void *ptr, const void *derived_ptr, struct uniqtype *t);
+extern __libcrunch_bounds_t (__attribute__((const)) __fetch_bounds_ool_via_dladdr)(const void *ptr, const void *derived_ptr, struct uniqtype *t);
 #ifdef LIBCRUNCH_NO_POINTER_TYPE_INFO
 #define __fetch_bounds_ool_to_use __fetch_bounds_ool_via_dladdr
 #else
@@ -1247,7 +1250,7 @@ extern inline unsigned long (__attribute__((always_inline,gnu_inline)) __clear_l
 extern inline void **(__attribute__((always_inline,gnu_inline/*,pure,__const__*/)) __libcrunch_base_stored_loc)(void *ptr)
 {
 	/* Produce the output in the clobbered register */
-	void **ret;
+	//void **ret;
 	//__asm__ ("mov $0x70, %0 \n"
 	//		 "shl $0x28, %0 \n"
 	//		 "xor %1, %0 \n": "=r"(ret) : "r"(ptr));
@@ -1257,7 +1260,7 @@ extern inline void **(__attribute__((always_inline,gnu_inline/*,pure,__const__*/
 extern inline unsigned *(__attribute__((always_inline,gnu_inline/*,pure,__const__*/)) __libcrunch_size_stored_loc)(void *ptr)
 {
 	/* Produce the output in the clobbered register */
-	unsigned *ret;
+	//unsigned *ret;
 	//__asm__ ("mov $0x08, %0 \n"
 	//		 "shl $0x28, %0 \n"
 	//		 "add %1, %0 \n": "=r"(ret) : "r"(((unsigned long) ptr)>>1));

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,12 +47,12 @@ ifeq ($(notdir $(CC)),crunchcc)
 export CC := cc
 endif
 
-ifeq ($(USE_REAL_LIBUNWIND),)
+ifeq ($(USE_FAKE_LIBUNWIND),)
+CFLAGS += -DUSE_REAL_LIBUNWIND
+LIBUNWIND_LDLIBS := -lunwind -lunwind-$(shell uname -m)
+else
 CFLAGS += -fno-omit-frame-pointer
 LIBUNWIND_LDLIBS :=
-else
-LIBUNWIND_LDLIBS := -lunwind -lunwind-`uname -m` 
-CFLAGS += -DUSE_REAL_LIBUNWIND
 endif
 
 # until binutils bug 13600 is fixed, gold is the linker we need

--- a/src/libcrunch.c
+++ b/src/libcrunch.c
@@ -2193,10 +2193,10 @@ can_hold_pointer_failed:
 out:
 	return 1; // fail, but program continues
 }
-extern void *__real___notify_copy(void *dest, const void *src, size_t n);
+extern void __real___notify_copy(void *dest, const void *src, size_t n);
 void **__libcrunch_ool_base_stored_addr(void *const *stored_ptr_addr);
 unsigned *__libcrunch_ool_size_stored_addr(void *const *stored_ptr_addr);
-void *__wrap___notify_copy(void *dest, const void *src, size_t n)
+void __wrap___notify_copy(void *dest, const void *src, size_t n)
 {
 	/* Do nothing if the shadow space is not initialized. */
 	/* WEIRD. If I replace "goto out" with "return dest" here, 
@@ -2224,8 +2224,9 @@ void *__wrap___notify_copy(void *dest, const void *src, size_t n)
 	orig_memmove(__libcrunch_ool_size_stored_addr(dest), 
 		__libcrunch_ool_size_stored_addr(src),
 		n * sizeof (unsigned) / sizeof (void*));
+
 out:
-	return __real___notify_copy(dest, src, n);
+	__real___notify_copy(dest, src, n);
 }
 
 struct bounds_cb_arg

--- a/src/libcrunch.c
+++ b/src/libcrunch.c
@@ -2230,13 +2230,13 @@ out:
 
 struct bounds_cb_arg
 {
-	struct uniqtype *passed_in_t;
+	const struct uniqtype *passed_in_t;
 	unsigned target_offset;
 	_Bool success;
-	struct uniqtype *matched_t;
-	struct uniqtype *innermost_containing_array_t;
+	const struct uniqtype *matched_t;
+	const struct uniqtype *innermost_containing_array_t;
 	unsigned innermost_containing_array_type_span_start_offset;
-	struct uniqtype *outermost_containing_array_t;
+	const struct uniqtype *outermost_containing_array_t;
 	unsigned outermost_containing_array_type_span_start_offset;
 	size_t accum_array_bounds;
 };
@@ -2327,7 +2327,7 @@ static int bounds_cb(struct uniqtype *spans, unsigned span_start_offset, unsigne
 	assert(0);
 }
 
-__libcrunch_bounds_t __fetch_bounds_internal(const void *obj, const void *derived, struct uniqtype *t)
+__libcrunch_bounds_t __fetch_bounds_internal(const void *obj, const void *derived, const struct uniqtype *t)
 {
 	if (!obj) goto return_min_bounds;
 	
@@ -2667,7 +2667,7 @@ __libcrunch_bounds_t
 
 /* Use this naive libdl-based version */
 __libcrunch_bounds_t 
-(__attribute__((pure,__const__)) __fetch_bounds_ool_via_dladdr)
+(__attribute__((const)) __fetch_bounds_ool_via_dladdr)
 (const void *ptr, const void *derived_ptr, struct uniqtype *t)
 {
 	if (!ptr) return __make_bounds(0, 1);

--- a/src/libcrunch.c
+++ b/src/libcrunch.c
@@ -2391,7 +2391,7 @@ __libcrunch_bounds_t __fetch_bounds_internal(const void *obj, const void *derive
 		{
 			// bounds are the whole array
 			const char *lower = (char*) alloc_start + arg.innermost_containing_array_type_span_start_offset;
-			const char *upper = (UNIQTYPE_ARRAY_LENGTH(arg.innermost_containing_array_t) == 0) ? /* use the allocation's limit */ 
+			const char *upper = !UNIQTYPE_HAS_KNOWN_LENGTH(arg.innermost_containing_array_t) ? /* use the allocation's limit */
 					alloc_start + alloc_size_bytes
 					: (char*) alloc_start + arg.innermost_containing_array_type_span_start_offset
 						+ (UNIQTYPE_ARRAY_LENGTH(arg.innermost_containing_array_t) * t->pos_maxoff);

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -290,7 +290,7 @@ static void init_shadow_entries(void)
 {
 	/* It's not just about wrapping functions. Initialise the globals.
 	 * FIXME: not sure why SoftBound doesn't do this. */
-	Elf64_auxv_t *auxv_array_start = get_auxv((const char **) environ, environ[0]);
+	Elf64_auxv_t *auxv_array_start = get_auxv((char **) environ, environ[0]);
 	if (!auxv_array_start) return;
 
 	struct auxv_limits lims = get_auxv_limits(auxv_array_start);

--- a/src/stubs.c
+++ b/src/stubs.c
@@ -124,7 +124,7 @@ int __can_hold_pointer_internal(const void *obj, const void *target)
 	return 1;
 }
 
-__libcrunch_bounds_t __fetch_bounds_internal(const void *ptr, const void *derived, struct uniqtype *t)
+__libcrunch_bounds_t __fetch_bounds_internal(const void *ptr, const void *derived, const struct uniqtype *t)
 {
 	return __libcrunch_max_bounds(ptr);
 }


### PR DESCRIPTION
Some recent changes in liballocs required some adjustments here, as the two libraries are closely linked together.
This MR also patches some compilation warnings.